### PR TITLE
fix(imaging): prevent new images from overwriting older files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 modules/__pycache__/
+.venv

--- a/modules/image_sequence.py
+++ b/modules/image_sequence.py
@@ -1,0 +1,82 @@
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CaptureFiles:
+    number: int
+    stem: str
+    image_path: str
+    metadata_path: str
+
+
+class CaptureFileSequence:
+    """Keeps image + metadata filenames moving forward across restarts."""
+
+    def __init__(self, image_dir, padding=5, counter_file=".last_image_number"):
+        self.image_dir = image_dir
+        self.padding = padding
+        self.counter_path = os.path.join(image_dir, counter_file)
+
+    def files_for(self, number):
+        stem = f"{number:0{self.padding}d}"
+        return CaptureFiles(
+            number=number,
+            stem=stem,
+            image_path=os.path.join(self.image_dir, f"{stem}.jpg"),
+            metadata_path=os.path.join(self.image_dir, f"{stem}.json"),
+        )
+
+    def last_saved_number(self, client_image_count=0):
+        return max(
+            0,
+            client_image_count,
+            self._read_counter(),
+            self._latest_number_in_image_dir(),
+        )
+
+    def remember_saved(self, number):
+        try:
+            os.makedirs(self.image_dir, exist_ok=True)
+            temp_counter_path = f"{self.counter_path}.tmp"
+            with open(temp_counter_path, "w") as f:
+                f.write(f"{number}\n")
+            os.replace(temp_counter_path, self.counter_path)
+        except OSError as e:
+            print(f"WARN: Could not update image counter file: {e}")
+
+    def _read_counter(self):
+        try:
+            with open(self.counter_path, "r") as f:
+                return max(0, int(f.read().strip() or "0"))
+        except FileNotFoundError:
+            return 0
+        except (OSError, ValueError) as e:
+            print(f"WARN: Could not read image counter file: {e}")
+            return 0
+
+    def _latest_number_in_image_dir(self):
+        try:
+            file_names = os.listdir(self.image_dir)
+        except FileNotFoundError:
+            return 0
+        except OSError as e:
+            print(f"WARN: Could not scan image directory for existing files: {e}")
+            return 0
+
+        latest_number = 0
+        for file_name in file_names:
+            number = self._number_from_file_name(file_name)
+            if number is not None:
+                latest_number = max(latest_number, number)
+        return latest_number
+
+    def _number_from_file_name(self, file_name):
+        stem, extension = os.path.splitext(file_name)
+        if extension.lower() not in {".jpg", ".jpeg", ".png", ".json"}:
+            return None
+
+        if stem.isdigit():
+            return int(stem)
+
+        return None

--- a/server.py
+++ b/server.py
@@ -14,6 +14,7 @@ import json
 import sys
 import time
 import os
+import subprocess
 
 import modules.AutopilotDevelopment.General.Operations.initialize as initialize
 import modules.AutopilotDevelopment.General.Operations.mode as autopilot_mode
@@ -460,12 +461,62 @@ def toggle_camera():
 
     return jsonify({"message": "Success!"}), 200
 
+def _v4l2_set(device: str, control: str, value) -> bool:
+    """Set a single V4L2 control via v4l2-ctl. Returns True on success."""
+    try:
+        result = subprocess.run(
+            ["v4l2-ctl", "-d", device, "--set-ctrl", f"{control}={value}"],
+            capture_output=True, text=True, timeout=2,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+        print(f"WARN: v4l2-ctl unavailable for {control}={value}: {e}")
+        return False
+    if result.returncode != 0:
+        # Driver will complain on stderr if the control name isn't recognised.
+        return False
+    return True
+
+def _apply_manual_exposure(device: str, exposure_units: int) -> None:
+    """Force manual exposure on a UVC camera, trying both UAPI naming schemes."""
+    # auto-exposure: 1 = Manual Mode, 3 = Aperture Priority Mode (auto).
+    if not (_v4l2_set(device, "auto_exposure", 1)
+            or _v4l2_set(device, "exposure_auto", 1)):
+        print("WARN: could not disable auto-exposure via v4l2-ctl; "
+              "manual shutter may not take effect")
+        return
+    if not (_v4l2_set(device, "exposure_time_absolute", exposure_units)
+            or _v4l2_set(device, "exposure_absolute", exposure_units)):
+        print(f"WARN: could not set manual exposure to {exposure_units} via v4l2-ctl")
+
+def _print_exposure_state(device: str) -> None:
+    """Log the camera's current exposure controls for verification."""
+    try:
+        result = subprocess.run(
+            ["v4l2-ctl", "-d", device, "--get-ctrl",
+             "auto_exposure,exposure_time_absolute,exposure_auto,exposure_absolute"],
+            capture_output=True, text=True, timeout=2,
+        )
+        if result.stdout:
+            print("Exposure controls:\n" + result.stdout.strip())
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
 def continuously_capture_images():
     global camera_connection
     global image_number
 
     if camera_connection is None or not camera_connection.isOpened():
         print("Initializing camera...")
+
+        # Configure manual exposure via v4l2-ctl BEFORE opening the device.
+        # OpenCV's V4L2 backend frequently fails to set auto-exposure
+        # (cap.set returns False and the control is silently ignored),
+        # so drive the UVC controls directly. Some kernels expose the
+        # controls as auto_exposure / exposure_time_absolute (newer UVC
+        # driver) and some as exposure_auto / exposure_absolute (older).
+        # Try both and accept whichever the driver accepts.
+        _apply_manual_exposure(CAMERA_DEVICE, CAMERA_EXPOSURE)
+
         camera_connection = cv2.VideoCapture(CAMERA_DEVICE, cv2.CAP_V4L2)
 
         camera_connection.set(cv2.CAP_PROP_FOURCC, cv2.VideoWriter_fourcc(*"MJPG"))
@@ -474,14 +525,8 @@ def continuously_capture_images():
         camera_connection.set(cv2.CAP_PROP_FPS, 30)
         camera_connection.set(cv2.CAP_PROP_BUFFERSIZE, 1)
 
-        # Force manual exposure so aircraft motion does not cause motion blur.
-        # On V4L2 UVC cameras CAP_PROP_AUTO_EXPOSURE uses 1=manual, 3=aperture-priority/auto.
-        # Set auto-exposure OFF *before* writing CAP_PROP_EXPOSURE, otherwise
-        # the driver silently ignores the manual exposure value.
-        if not camera_connection.set(cv2.CAP_PROP_AUTO_EXPOSURE, 1):
-            print("WARN: failed to disable auto-exposure; manual shutter may not apply")
-        if not camera_connection.set(cv2.CAP_PROP_EXPOSURE, CAMERA_EXPOSURE):
-            print(f"WARN: failed to set manual exposure to {CAMERA_EXPOSURE}")
+        # Re-apply after open: opening the device can reset UVC controls on some drivers.
+        _apply_manual_exposure(CAMERA_DEVICE, CAMERA_EXPOSURE)
 
         if not camera_connection.isOpened():
             print("ERROR: Could not open camera")
@@ -495,9 +540,7 @@ def continuously_capture_images():
         print("Width:", camera_connection.get(cv2.CAP_PROP_FRAME_WIDTH))
         print("Height:", camera_connection.get(cv2.CAP_PROP_FRAME_HEIGHT))
         print("FPS:", camera_connection.get(cv2.CAP_PROP_FPS))
-        print("Auto-exposure mode:", camera_connection.get(cv2.CAP_PROP_AUTO_EXPOSURE))
-        print("Exposure:", camera_connection.get(cv2.CAP_PROP_EXPOSURE))
-        print("Gain:", camera_connection.get(cv2.CAP_PROP_GAIN))
+        _print_exposure_state(CAMERA_DEVICE)
         print("Gain:", camera_connection.get(cv2.CAP_PROP_GAIN))
 
     print("Camera ready, waiting for PPS pulses.")

--- a/server.py
+++ b/server.py
@@ -19,6 +19,7 @@ import modules.AutopilotDevelopment.General.Operations.initialize as initialize
 import modules.AutopilotDevelopment.General.Operations.mode as autopilot_mode
 import modules.AutopilotDevelopment.General.Operations.mission as mission
 import modules.AutopilotDevelopment.Plane.Operations.altitude as autopilot_altitude
+import modules.image_sequence as image_sequence
 import modules.payload as payload
 
 
@@ -70,6 +71,7 @@ def _pps_open() -> int:
     return os.open(PPS_DEVICE, os.O_RDWR)
 # ─────────────────────────────────────────────────────────────────────────────
 IMAGE_SAVE_DIR = "/home/suavgeopi/images"
+capture_sequence = image_sequence.CaptureFileSequence(IMAGE_SAVE_DIR)
 
 camera_connection = None
 vehicle_connection = None
@@ -388,13 +390,16 @@ def _image_writer():
         try:
             if item is None:  # poison pill (only used at process shutdown)
                 break
-            file_name, frame, metadata = item
+            capture_files, frame, metadata = item
             try:
-                cv2.imwrite(os.path.join(IMAGE_SAVE_DIR, f'{file_name}.jpg'), frame)
-                with open(os.path.join(IMAGE_SAVE_DIR, f'{file_name}.json'), 'w') as f:
+                os.makedirs(IMAGE_SAVE_DIR, exist_ok=True)
+                if not cv2.imwrite(capture_files.image_path, frame):
+                    raise OSError(f"cv2.imwrite returned false for {capture_files.image_path}")
+                with open(capture_files.metadata_path, 'w') as f:
                     json.dump(metadata, f)
+                capture_sequence.remember_saved(capture_files.number)
             except Exception as e:
-                print(f"WARN: Failed to save {file_name}: {e}")
+                print(f"WARN: Failed to save {capture_files.stem}: {e}")
         finally:
             _save_queue.task_done()
 
@@ -415,7 +420,7 @@ def toggle_camera():
     try:
         json_data = request.json
         requested_state = bool(json_data["is_camera_on"])
-        image_number = int(json_data["image_count"])
+        client_image_count = int(json_data.get("image_count", 0) or 0)
     except Exception as e:
         print("Could not interpret toggle_camera payload:", e)
         return jsonify({"error": "Invalid payload"}), 400
@@ -436,13 +441,14 @@ def toggle_camera():
                         "error": "Previous camera thread is still running. "
                                  "Check PPS signal / camera USB and try again.",
                     }), 503
+            image_number = capture_sequence.last_saved_number(client_image_count)
             stop_camera_thread.clear()
             _ensure_writer_thread()
             camera_thread = threading.Thread(
                 target=continuously_capture_images, name="camera-capture", daemon=True,
             )
             camera_thread.start()
-            print("Starting camera")
+            print(f"Starting camera at {capture_sequence.files_for(image_number + 1).stem}")
         else:
             print("Stopping Camera")
             stop_camera_thread.set()
@@ -514,11 +520,11 @@ def take_picture(image_number, camera_connection, metadata):
         print(f"WARN: Failed to capture frame {image_number}")
         return
 
-    file_name = f'{image_number:05d}'
-    print(f"DEBUG: Image {file_name} captured ({frame.shape[1]}x{frame.shape[0]}), queuing write")
+    capture_files = capture_sequence.files_for(image_number)
+    print(f"DEBUG: Image {capture_files.stem} captured ({frame.shape[1]}x{frame.shape[0]}), queuing write")
 
     # Enqueue for async disk write — keeps the capture loop tight
-    _save_queue.put((file_name, frame, metadata))
+    _save_queue.put((capture_files, frame, metadata))
 
 @app.route("/heartbeat-validate")
 def heartbeat_validate():

--- a/server.py
+++ b/server.py
@@ -27,6 +27,11 @@ VEHICLE_PORT = "udp:127.0.0.1:5006"
 PPS_DEVICE = "/dev/pps0"  # kernel PPS driver via dtoverlay=pps-gpio,gpiopin=4
 CAMERA_DEVICE = "/dev/video0"
 
+# Manual exposure (shutter) settings. The camera is mounted on a moving
+# aircraft, so leaving exposure on auto produces motion-blurred frames.
+# UVC/V4L2 expresses exposure_absolute in units of 100 µs.
+CAMERA_EXPOSURE = 1   # 1 * 100µs = 100 µs shutter
+
 # ── Kernel PPSAPI (linux/pps.h) ──────────────────────────────────────────────
 class _PPSKTime(ctypes.Structure):
     _fields_ = [("sec", ctypes.c_int64), ("nsec", ctypes.c_int32), ("flags", ctypes.c_uint32)]
@@ -469,6 +474,15 @@ def continuously_capture_images():
         camera_connection.set(cv2.CAP_PROP_FPS, 30)
         camera_connection.set(cv2.CAP_PROP_BUFFERSIZE, 1)
 
+        # Force manual exposure so aircraft motion does not cause motion blur.
+        # On V4L2 UVC cameras CAP_PROP_AUTO_EXPOSURE uses 1=manual, 3=aperture-priority/auto.
+        # Set auto-exposure OFF *before* writing CAP_PROP_EXPOSURE, otherwise
+        # the driver silently ignores the manual exposure value.
+        if not camera_connection.set(cv2.CAP_PROP_AUTO_EXPOSURE, 1):
+            print("WARN: failed to disable auto-exposure; manual shutter may not apply")
+        if not camera_connection.set(cv2.CAP_PROP_EXPOSURE, CAMERA_EXPOSURE):
+            print(f"WARN: failed to set manual exposure to {CAMERA_EXPOSURE}")
+
         if not camera_connection.isOpened():
             print("ERROR: Could not open camera")
             return
@@ -481,6 +495,10 @@ def continuously_capture_images():
         print("Width:", camera_connection.get(cv2.CAP_PROP_FRAME_WIDTH))
         print("Height:", camera_connection.get(cv2.CAP_PROP_FRAME_HEIGHT))
         print("FPS:", camera_connection.get(cv2.CAP_PROP_FPS))
+        print("Auto-exposure mode:", camera_connection.get(cv2.CAP_PROP_AUTO_EXPOSURE))
+        print("Exposure:", camera_connection.get(cv2.CAP_PROP_EXPOSURE))
+        print("Gain:", camera_connection.get(cv2.CAP_PROP_GAIN))
+        print("Gain:", camera_connection.get(cv2.CAP_PROP_GAIN))
 
     print("Camera ready, waiting for PPS pulses.")
     try:


### PR DESCRIPTION
I've fixed the issue where new images would overwrite older images. This has been solved by creating a counter in $HOME/images/.last_image_counter. This also reduces the greatly increasing lag when counting files since we use a counter instead of reading all the files in the images directory. We will test this today and we can merge after.